### PR TITLE
Update zepto-dnd.js

### DIFF
--- a/zepto-dnd.js
+++ b/zepto-dnd.js
@@ -301,7 +301,7 @@
     if (this.opts.disabled) return false
 
     e.stopPropagation() // stops the browser from redirecting.
-    // e.preventDefault()
+    e.preventDefault()
 
     if (!dragging.el) return
 


### PR DESCRIPTION
Missing e.preventDefault() on drop was preventing drop to work on iframes in firefox.

Have not tested this in every scenario but it seems to work fine.
