### PR TITLE
Enable page scrolling when dragging things around

### DIFF
--- a/zepto-dnd.js
+++ b/zepto-dnd.js
@@ -1,5 +1,72 @@
 !function($) {
   var nextId = 0
+
+  var Scroller = function() {
+  };
+
+  Scroller.prototype.scrollEvent = function(element, originalEvent) {
+    var event = new CustomEvent('dragscroll', {
+      detail: {
+        element: [ $(element) ],
+        originalEvent: originalEvent
+      }
+    });
+    document.dispatchEvent(event);
+  };
+
+  Scroller.prototype.scroll = function(e) {
+    var
+      d = e.detail,
+      originalEvent = d.originalEvent.originalEvent || d.originalEvent,
+      winWidth = window.innerWidth,
+      winHeight = window.innerHeight,
+      scrollSpeed = 5,
+      scrollSensitivity = 50,
+      step = 20,
+      x,
+      y
+
+    e.stopPropagation();
+
+    if (originalEvent.pageY) {
+      y = originalEvent.pageY - window.pageYOffset
+    }
+
+    if (originalEvent.pageX) {
+      x = originalEvent.pageX - window.pageXOffset
+    }
+
+    var moveY;
+    if (y >= winHeight - scrollSensitivity) {
+      moveY = window.scrollY + step;
+    } else if (y <= scrollSensitivity) {
+      moveY = window.scrollY - step;
+    }
+
+    var moveX;
+    if (x >= winWidth - scrollSensitivity) {
+      moveX = window.scrollX + step;
+    } else if (x <= scrollSensitivity) {
+      moveX = window.scrollX - step;
+    }
+
+    if (moveX) {
+      window.scrollTo(moveX, window.pageYOffset);
+    } else if (moveY) {
+      window.scrollTo(window.pageXOffset, moveY);
+    }
+  };
+
+  // https://github.com/rkusa/zepto-dnd/issues/19#issuecomment-77806753
+  var needScroller = navigator.userAgent.toLowerCase().indexOf('gecko/') >= 0;
+  if (needScroller) {
+    var scroller = new Scroller();
+    document.addEventListener('dragover', function(e) {
+      scroller.scrollEvent(e.explicitOriginalTarget, e);
+    });
+    document.addEventListener('dragscroll', scroller.scroll.bind(scroller));
+  };
+
   var Dragging = function() {
     this.eventHandler = $('<div />')
     this.origin = this.el = null


### PR DESCRIPTION
Adds a `Scroller` object when the browser is firefox using a crude
check against `navigator.userAgent`.

The `Scroller.scroll` method tries to detect whether user is currently
dragging something on the edge of the viewport. When a certain threshold
(hardcoded in variable `scrollSensitivity`) is reached, it tries to scroll
the page by `scrollSpeed` pixel.

Closes #19