### PR TITLE
Drag ux

### DIFF
--- a/zepto-dnd.js
+++ b/zepto-dnd.js
@@ -93,7 +93,7 @@
     return this
   }
 
-  Dragging.prototype.start = function(origin, el) {
+  Dragging.prototype.start = function(origin, el, evt) {
     this.origin = origin
     this.el = el
     this.eventHandler.trigger('dragging:start')
@@ -107,6 +107,21 @@
           this.placeholder.addClass(origin.opts.placeholder);
         }
       }
+    }
+
+    this.dragImageEl = this.dragImageEl || document.createElement('img');
+    if (origin.opts.dragImage === false) {
+      // noop
+    } else if (typeof origin.opts.dragImage === 'string') {
+      this.dragImageEl.src = origin.opts.dragImage
+    } else if (origin.opts.dragImage instanceof HTMLElement) {
+      this.dragImageEl = origin.opts.dragImage;
+    } else {
+      delete this.dragImageEl;
+    }
+    if (this.dragImageEl) {
+      evt.dataTransfer.setDragImage(this.dragImageEl, 0, 0);
+      delete this.dragImageEl;
     }
 
     return this.el
@@ -379,7 +394,7 @@
       e.dataTransfer.setData('text/plain', '42')
     } catch(e) {}
 
-    dragging.start(this, this.el).addClass('dragging')
+    dragging.start(this, this.el, e).addClass('dragging')
   }
 
   Draggable.prototype.end = function(e) {
@@ -697,7 +712,7 @@
       e.dataTransfer.setData('text/plain', '42')
     } catch(e) {}
 
-    dragging.start(this, $(target)).addClass('dragging')
+    dragging.start(this, $(target), e).addClass('dragging')
     this.index = dragging.el.index()
 
     if (this.opts.forcePlaceholderSize) {

--- a/zepto-dnd.js
+++ b/zepto-dnd.js
@@ -97,6 +97,18 @@
     this.origin = origin
     this.el = el
     this.eventHandler.trigger('dragging:start')
+
+    if (origin.opts.clonePlaceholder) {
+      if (typeof origin.opts.clonePlaceholder === 'function') {
+        this.placeholder = origin.opts.clonePlaceholder.call(this);
+      } else if (origin.opts.clonePlaceholder === true) {
+        this.placeholder = $(this.el[0].cloneNode(true));
+        if (origin.opts.placeholder && this.placeholder) {
+          this.placeholder.addClass(origin.opts.placeholder);
+        }
+      }
+    }
+
     return this.el
   }
 
@@ -470,7 +482,11 @@
     // hide placeholder, if set (e.g. enter the droppable after
     // entering a sortable)
     if (dragging.placeholder && !(effectAllowed === 'copymove' && this.opts.clone)) {
-      dragging.placeholder.hide()
+      if (this.opts.clonePlaceholder) {
+        this.el.append(dragging.placeholder);
+      } else {
+        dragging.placeholder.hide();
+      }
     }
 
     if (this.opts.hoverClass && this.accept)
@@ -701,6 +717,10 @@
     // stop if event is fired on the placeholder
     var child = e.currentTarget, isContainer = child === this.el[0]
     if (child === this.placeholder[0]) return
+
+    if (dragging.placeholder) {
+      this.placeholder = dragging.placeholder;
+    }
 
     // the container fallback is only necessary for empty sortables
     if (isContainer && !this.isEmpty && this.placeholder.parent().length)

--- a/zepto-dnd.js
+++ b/zepto-dnd.js
@@ -105,6 +105,13 @@
     this.eventHandler.trigger('dragging:stop')
   }
 
+  Dragging.prototype.parentDraggable = function(state, args) {
+    if (this.opts.handle && args[0] && args[0].target) {
+      var $parent = $(args[0].target).closest(this.opts.items);
+      $parent.prop('draggable', state);
+    }
+  }
+
   var dragging = $.dragging = parent.$.dragging || new Dragging()
 
   // from https://github.com/rkusa/selector-observer
@@ -303,7 +310,6 @@
     this.el
     .on('dragstart', $.proxy(this.start, this))
     .on('dragend',   $.proxy(this.end, this))
-    .prop('draggable', true)
 
     // Prevents dragging from starting on specified elements.
     this.el
@@ -314,6 +320,8 @@
       this.el
       .on('mouseenter', this.opts.handle, $.proxy(this.enable, this))
       .on('mouseleave', this.opts.handle, $.proxy(this.disable, this))
+    } else {
+      this.el.prop('draggable', true)
     }
 
     var self = this
@@ -340,10 +348,12 @@
   }
 
   Draggable.prototype.enable = function() {
+    dragging.parentDraggable.call(this, true, arguments);
     this.opts.disabled = false
   }
 
   Draggable.prototype.disable = function() {
+    dragging.parentDraggable.call(this, false, arguments);
     this.opts.disabled = true
   }
 
@@ -550,7 +560,6 @@
     .on('dragover',  this.opts.items, $.proxy(this.over, this))
     .on('dragend',   this.opts.items, $.proxy(this.end, this))
     .on('drop',      this.opts.items, $.proxy(this.drop, this))
-    .find(this.opts.items).prop('draggable', true)
 
     this.el
     .on('dragenter',  $.proxy(this.enter, this))
@@ -564,6 +573,8 @@
       this.el
       .on('mouseenter', this.opts.handle, $.proxy(this.enable, this))
       .on('mouseleave', this.opts.handle, $.proxy(this.disable, this))
+    } else {
+      this.el.find(this.opts.items).prop('draggable', true)
     }
 
     dragging
@@ -576,7 +587,9 @@
     })
 
     this.observer = new SelectorObserver(this.el[0], this.opts.items, function() {
-      $(this).prop('draggable', true)
+      if (!self.opts.handle) {
+        $(this).prop('draggable', true)
+      }
     }, function() {
       if (this === self.placeholder[0]) {
         return // ignore placeholder
@@ -620,10 +633,12 @@
   }
 
   Sortable.prototype.enable = function() {
+    dragging.parentDraggable.call(this, true, arguments);
     this.opts.disabled = false
   }
 
   Sortable.prototype.disable = function() {
+    dragging.parentDraggable.call(this, false, arguments);
     this.opts.disabled = true
   }
 


### PR DESCRIPTION
This PR includes changes for #21.  Real diff for this PR is https://github.com/rchavik/zepto-dnd/compare/2c694d3...drag-ux.

- 3cf41c3: When `handle` is used, we do not automatically set `draggable` attribute on the element.
  This allows text within the draggable element to be selectable. The `draggable=true` attribute will be toggled by `Draggable|Sortable.prototype.enable|disable` (via `mouseenter|mouseleave` events)

- 2b2c323: Add new option `clonePlaceholder`, which valid values: `true|function`. When function is passed, it should return a jQuery/zepto wrapped element. (only tested with jQuery though)

- 6f6dd53:  Add an option to disable dragImage since it might be desirable to disable the default dragImage
when `clonePlaceholder` is in use. You can also set a custom dragImage by passing in a string containing a valid url to an image resource.

Let me know if you want these features split into separate PRs.

I'm not including the sorting animation for now as it's still not working well. If anyone wants to help, it's can be found my fork under `animation-wip` branch. Would love to get some help on it.

Known issues:
- Instances are sometimes left in a disabled state (this.opts.disabled == false) causing things to fail. I'm not sure what's causing this. I'm guessing maybe a race condition somewhere?