### PR TITLE
Update zepto-dnd.js

### DIFF
--- a/zepto-dnd.js
+++ b/zepto-dnd.js
@@ -378,7 +378,7 @@
     if (this.opts.disabled || this.cancel) return false
 
     e = e.originalEvent || e // zepto <> jquery compatibility
-    //e.dataTransfer.effectAllowed = 'copy'
+    
     try { // IE fix
       // FF fix: set some data ....
       e.dataTransfer.setData('text/plain', '42')

--- a/zepto-dnd.js
+++ b/zepto-dnd.js
@@ -378,7 +378,7 @@
     if (this.opts.disabled || this.cancel) return false
 
     e = e.originalEvent || e // zepto <> jquery compatibility
-    e.dataTransfer.effectAllowed = 'copy'
+    //e.dataTransfer.effectAllowed = 'copy'
     try { // IE fix
       // FF fix: set some data ....
       e.dataTransfer.setData('text/plain', '42')


### PR DESCRIPTION
Line 381 commented
Now the dataTransfer object can use 'move' type of drag instead 'copy' natively